### PR TITLE
Sometimes image not being drawn on canvas in img demo

### DIFF
--- a/img/index.html
+++ b/img/index.html
@@ -28,9 +28,9 @@
 		/*
 			prepare the image and canvas context
 		*/
-		var img = document.getElementById('image');
 		var ctx = document.getElementById('canvas').getContext('2d');
-		ctx.drawImage(img, 0, 0);
+		var img = document.getElementById('image');
+		img.onload = () => ctx.drawImage(img, 0, 0);
 		/*
 			a function to transform an RGBA image to grayscale
 		*/


### PR DESCRIPTION
Because loading the img is async, and sometimes it's slow. `ctx.drawImage` draws an empty image on canvas and shows nothing.
By using `img.onload` we ensure it's loaded before calling `ctx.drawImage`.