### PR TITLE
Style/variable cleanups

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 4,
+  "semi": true,
+  "useTabs": true,
+  "printWidth": 256
+}

--- a/lploc.js
+++ b/lploc.js
@@ -1,8 +1,7 @@
 /* This library is released under the MIT license, see https://github.com/nenadmarkus/picojs */
-var lploc = {}
+var lploc = {};
 
-lploc.unpack_localizer = function(bytes)
-{
+lploc.unpack_localizer = function (bytes) {
 	//
 	const dview = new DataView(new ArrayBuffer(4));
 	let p = 0;
@@ -10,16 +9,28 @@ lploc.unpack_localizer = function(bytes)
 		read the number of stages, scale multiplier (applied after each stage),
 		number of trees per stage and depth of each tree
 	*/
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const nstages = dview.getInt32(0, true);
 	p = p + 4;
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const scalemul = dview.getFloat32(0, true);
 	p = p + 4;
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const ntreesperstage = dview.getInt32(0, true);
 	p = p + 4;
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const tdepth = dview.getInt32(0, true);
 	p = p + 4;
 	/*
@@ -27,22 +38,23 @@ lploc.unpack_localizer = function(bytes)
 	*/
 	const tcodes_ls = [];
 	const tpreds_ls = [];
-	for(let i=0; i<nstages; ++i)
-	{
+	for (let i = 0; i < nstages; ++i) {
 		// read the trees for this stage
-		for(let j=0; j<ntreesperstage; ++j)
-		{
+		for (let j = 0; j < ntreesperstage; ++j) {
 			// binary tests (we can read all of them at once)
-			Array.prototype.push.apply(tcodes_ls, bytes.slice(p, p+4*Math.pow(2, tdepth)-4));
-			p = p + 4*Math.pow(2, tdepth)-4;
+			Array.prototype.push.apply(tcodes_ls, bytes.slice(p, p + 4 * Math.pow(2, tdepth) - 4));
+			p = p + 4 * Math.pow(2, tdepth) - 4;
 			// read the prediction in the leaf nodes of the tree
-			for(let k=0; k<Math.pow(2, tdepth); ++k)
-				for(let l=0; l<2; ++l)
-				{
-					dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+			for (let k = 0; k < Math.pow(2, tdepth); ++k) {
+				for (let l = 0; l < 2; ++l) {
+					dview.setUint8(0, bytes[p + 0]);
+					dview.setUint8(1, bytes[p + 1]);
+					dview.setUint8(2, bytes[p + 2]);
+					dview.setUint8(3, bytes[p + 3]);
 					tpreds_ls.push(dview.getFloat32(0, true));
 					p = p + 4;
 				}
+			}
 		}
 	}
 	const tcodes = new Int8Array(tcodes_ls);
@@ -50,39 +62,36 @@ lploc.unpack_localizer = function(bytes)
 	/*
 		construct the location estimaton function
 	*/
-	function loc_fun(r, c, s, pixels, nrows, ncols, ldim)
-	{
+	function loc_fun(r, c, s, pixels, nrows, ncols, ldim) {
 		let root = 0;
 		const pow2tdepth = Math.pow(2, tdepth) >> 0; // '>>0' transforms this number to int
 
-		for(let i=0; i<nstages; ++i)
-		{
-			let dr=0.0, dc=0.0;
+		for (let i = 0; i < nstages; ++i) {
+			let dr = 0.0,
+				dc = 0.0;
 
-			for(let j=0; j<ntreesperstage; ++j)
-			{
+			for (let j = 0; j < ntreesperstage; ++j) {
 				let idx = 0;
-				for(var k=0; k<tdepth; ++k)
-				{
-					const r1 = Math.min(nrows-1, Math.max(0, (256*r+tcodes[root + 4*idx + 0]*s)>>8));
-					const c1 = Math.min(ncols-1, Math.max(0, (256*c+tcodes[root + 4*idx + 1]*s)>>8));
-					const r2 = Math.min(nrows-1, Math.max(0, (256*r+tcodes[root + 4*idx + 2]*s)>>8));
-					const c2 = Math.min(ncols-1, Math.max(0, (256*c+tcodes[root + 4*idx + 3]*s)>>8));
+				for (var k = 0; k < tdepth; ++k) {
+					const r1 = Math.min(nrows - 1, Math.max(0, (256 * r + tcodes[root + 4 * idx + 0] * s) >> 8));
+					const c1 = Math.min(ncols - 1, Math.max(0, (256 * c + tcodes[root + 4 * idx + 1] * s) >> 8));
+					const r2 = Math.min(nrows - 1, Math.max(0, (256 * r + tcodes[root + 4 * idx + 2] * s) >> 8));
+					const c2 = Math.min(ncols - 1, Math.max(0, (256 * c + tcodes[root + 4 * idx + 3] * s) >> 8));
 
-					idx = 2*idx + 1 + (pixels[r1*ldim+c1] > pixels[r2*ldim+c2])
+					idx = 2 * idx + 1 + (pixels[r1 * ldim + c1] > pixels[r2 * ldim + c2]);
 				}
 
-				const lutidx = 2*(ntreesperstage*pow2tdepth*i + pow2tdepth*j + idx - (pow2tdepth - 1))
+				const lutidx = 2 * (ntreesperstage * pow2tdepth * i + pow2tdepth * j + idx - (pow2tdepth - 1));
 				dr += tpreds[lutidx + 0];
 				dc += tpreds[lutidx + 1];
 
-				root += 4*pow2tdepth - 4;
+				root += 4 * pow2tdepth - 4;
 			}
 
-			r = r + dr*s;
-			c = c + dc*s;
+			r = r + dr * s;
+			c = c + dc * s;
 
-			s = s*scalemul;
+			s = s * scalemul;
 		}
 
 		return [r, c];
@@ -90,30 +99,29 @@ lploc.unpack_localizer = function(bytes)
 	/*
 		this function applies random perturbations to the default rectangle (r, c, s)
 	*/
-	function loc_fun_with_perturbs(r, c, s, nperturbs, image)
-	{
-		const rows=[], cols=[];
+	function loc_fun_with_perturbs(r, c, s, nperturbs, image) {
+		const rows = [],
+			cols = [];
 
-		for(let i=0; i<nperturbs; ++i)
-		{
-			const _s = s*(0.925 + 0.15*Math.random());
-			let _r = r + s*0.15*(0.5 - Math.random());
-			let _c = c + s*0.15*(0.5 - Math.random());
+		for (let i = 0; i < nperturbs; ++i) {
+			const _s = s * (0.925 + 0.15 * Math.random());
+			let _r = r + s * 0.15 * (0.5 - Math.random());
+			let _c = c + s * 0.15 * (0.5 - Math.random());
 
-			[_r, _c] = loc_fun(_r, _c, _s, image.pixels, image.nrows, image.ncols, image.ldim)
+			[_r, _c] = loc_fun(_r, _c, _s, image.pixels, image.nrows, image.ncols, image.ldim);
 
-			rows.push(_r)
-			cols.push(_c)
+			rows.push(_r);
+			cols.push(_c);
 		}
 
 		// return the median along each axis
-		rows.sort()
-		cols.sort()
+		rows.sort();
+		cols.sort();
 
-		return [rows[Math.round(nperturbs/2)], cols[Math.round(nperturbs/2)]];
+		return [rows[Math.round(nperturbs / 2)], cols[Math.round(nperturbs / 2)]];
 	}
 	/*
 		we're done
 	*/
 	return loc_fun_with_perturbs;
-}
+};

--- a/lploc.js
+++ b/lploc.js
@@ -1,5 +1,5 @@
 /* This library is released under the MIT license, see https://github.com/nenadmarkus/picojs */
-lploc = {}
+var lploc = {}
 
 lploc.unpack_localizer = function(bytes)
 {

--- a/pico.js
+++ b/pico.js
@@ -1,5 +1,5 @@
 /* This library is released under the MIT license, see https://github.com/nenadmarkus/picojs */
-pico = {}
+var pico = {}
 
 pico.unpack_cascade = function(bytes)
 {
@@ -188,7 +188,7 @@ pico.instantiate_detection_memory = function(size)
 		memory[n] = dets;
 		n = (n+1)%memory.length;
 		dets = [];
-		for(i=0; i<memory.length; ++i)
+		for(let i=0; i<memory.length; ++i)
 			dets = dets.concat(memory[i]);
 		//
 		return dets;

--- a/pico.js
+++ b/pico.js
@@ -1,8 +1,7 @@
 /* This library is released under the MIT license, see https://github.com/nenadmarkus/picojs */
-var pico = {}
+var pico = {};
 
-pico.unpack_cascade = function(bytes)
-{
+pico.unpack_cascade = function (bytes) {
 	//
 	const dview = new DataView(new ArrayBuffer(4));
 	/*
@@ -13,36 +12,47 @@ pico.unpack_cascade = function(bytes)
 	/*
 		read the depth (size) of each tree first: a 32-bit signed integer
 	*/
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const tdepth = dview.getInt32(0, true);
-	p = p + 4
+	p = p + 4;
 	/*
 		next, read the number of trees in the cascade: another 32-bit signed integer
 	*/
-	dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+	dview.setUint8(0, bytes[p + 0]);
+	dview.setUint8(1, bytes[p + 1]);
+	dview.setUint8(2, bytes[p + 2]);
+	dview.setUint8(3, bytes[p + 3]);
 	const ntrees = dview.getInt32(0, true);
-	p = p + 4
+	p = p + 4;
 	/*
 		read the actual trees and cascade thresholds
 	*/
 	const tcodes_ls = [];
 	const tpreds_ls = [];
 	const thresh_ls = [];
-	for(let t=0; t<ntrees; ++t)
-	{
+	for (let t = 0; t < ntrees; ++t) {
 		// read the binary tests placed in internal tree nodes
 		Array.prototype.push.apply(tcodes_ls, [0, 0, 0, 0]);
-		Array.prototype.push.apply(tcodes_ls, bytes.slice(p, p+4*Math.pow(2, tdepth)-4));
-		p = p + 4*Math.pow(2, tdepth)-4;
+		Array.prototype.push.apply(tcodes_ls, bytes.slice(p, p + 4 * Math.pow(2, tdepth) - 4));
+		p = p + 4 * Math.pow(2, tdepth) - 4;
 		// read the prediction in the leaf nodes of the tree
-		for(let i=0; i<Math.pow(2, tdepth); ++i)
-		{
-			dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+		for (let i = 0; i < Math.pow(2, tdepth); ++i) {
+			dview.setUint8(0, bytes[p + 0]);
+			dview.setUint8(1, bytes[p + 1]);
+			dview.setUint8(2, bytes[p + 2]);
+			dview.setUint8(3, bytes[p + 3]);
 			tpreds_ls.push(dview.getFloat32(0, true));
 			p = p + 4;
 		}
 		// read the threshold
-		dview.setUint8(0, bytes[p+0]), dview.setUint8(1, bytes[p+1]), dview.setUint8(2, bytes[p+2]), dview.setUint8(3, bytes[p+3]);
+
+		dview.setUint8(0, bytes[p + 0]);
+		dview.setUint8(1, bytes[p + 1]);
+		dview.setUint8(2, bytes[p + 2]);
+		dview.setUint8(3, bytes[p + 3]);
 		thresh_ls.push(dview.getFloat32(0, true));
 		p = p + 4;
 	}
@@ -52,38 +62,37 @@ pico.unpack_cascade = function(bytes)
 	/*
 		construct the classification function from the read data
 	*/
-	function classify_region(r, c, s, pixels, ldim)
-	{
-		 r = 256*r;
-		 c = 256*c;
-		 let root = 0;
-		 let o = 0.0;
-		 const pow2tdepth = Math.pow(2, tdepth) >> 0; // '>>0' transforms this number to int
+	function classify_region(r, c, s, pixels, ldim) {
+		r = 256 * r;
+		c = 256 * c;
+		let root = 0;
+		let o = 0.0;
+		const pow2tdepth = Math.pow(2, tdepth) >> 0; // '>>0' transforms this number to int
 
-		 for(let i=0; i<ntrees; ++i)
-		 {
+		for (let i = 0; i < ntrees; ++i) {
 			let idx = 1;
-			for(let j=0; j<tdepth; ++j)
+			for (let j = 0; j < tdepth; ++j) {
 				// we use '>> 8' here to perform an integer division: this seems important for performance
-				idx = 2*idx + (pixels[((r+tcodes[root + 4*idx + 0]*s) >> 8)*ldim+((c+tcodes[root + 4*idx + 1]*s) >> 8)]<=pixels[((r+tcodes[root + 4*idx + 2]*s) >> 8)*ldim+((c+tcodes[root + 4*idx + 3]*s) >> 8)]);
+				idx = 2 * idx + (pixels[((r + tcodes[root + 4 * idx + 0] * s) >> 8) * ldim + ((c + tcodes[root + 4 * idx + 1] * s) >> 8)] <= pixels[((r + tcodes[root + 4 * idx + 2] * s) >> 8) * ldim + ((c + tcodes[root + 4 * idx + 3] * s) >> 8)]);
+			}
 
-			 o = o + tpreds[pow2tdepth*i + idx-pow2tdepth];
+			o = o + tpreds[pow2tdepth * i + idx - pow2tdepth];
 
-			 if(o<=thresh[i])
-				 return -1;
+			if (o <= thresh[i]) {
+				return -1;
+			}
 
-			 root += 4*pow2tdepth;
+			root += 4 * pow2tdepth;
 		}
-		return o - thresh[ntrees-1];
+		return o - thresh[ntrees - 1];
 	}
 	/*
 		we're done
 	*/
 	return classify_region;
-}
+};
 
-pico.run_cascade = function(image, classify_region, params)
-{
+pico.run_cascade = function (image, classify_region, params) {
 	const pixels = image.pixels;
 	const nrows = image.nrows;
 	const ncols = image.ncols;
@@ -97,63 +106,66 @@ pico.run_cascade = function(image, classify_region, params)
 	let scale = minsize;
 	const detections = [];
 
-	while(scale<=maxsize)
-	{
-		const step = Math.max(shiftfactor*scale, 1) >> 0; // '>>0' transforms this number to int
-		const offset = (scale/2 + 1) >> 0;
+	while (scale <= maxsize) {
+		const step = Math.max(shiftfactor * scale, 1) >> 0; // '>>0' transforms this number to int
+		const offset = (scale / 2 + 1) >> 0;
 
-		for(let r=offset; r<=nrows-offset; r+=step)
-			for(let c=offset; c<=ncols-offset; c+=step)
-			{
+		for (let r = offset; r <= nrows - offset; r += step) {
+			for (let c = offset; c <= ncols - offset; c += step) {
 				const q = classify_region(r, c, scale, pixels, ldim);
-				if (q > 0.0)
+				if (q > 0.0) {
 					detections.push([r, c, scale, q]);
+				}
 			}
-		
-		scale = scale*scalefactor;
+		}
+
+		scale = scale * scalefactor;
 	}
 
-    return detections;
-}
+	return detections;
+};
 
-pico.cluster_detections = function(dets, iouthreshold)
-{
+pico.cluster_detections = function (dets, iouthreshold) {
 	/*
 		sort detections by their score
 	*/
-	dets = dets.sort(function(a, b) {
+	dets = dets.sort(function (a, b) {
 		return b[3] - a[3];
 	});
 	/*
 		this helper function calculates the intersection over union for two detections
 	*/
-	function calculate_iou(det1, det2)
-	{
+	function calculate_iou(det1, det2) {
 		// unpack the position and size of each detection
-		const r1=det1[0], c1=det1[1], s1=det1[2];
-		const r2=det2[0], c2=det2[1], s2=det2[2];
+		const r1 = det1[0],
+			c1 = det1[1],
+			s1 = det1[2];
+		const r2 = det2[0],
+			c2 = det2[1],
+			s2 = det2[2];
 		// calculate detection overlap in each dimension
-		const overr = Math.max(0, Math.min(r1+s1/2, r2+s2/2) - Math.max(r1-s1/2, r2-s2/2));
-		const overc = Math.max(0, Math.min(c1+s1/2, c2+s2/2) - Math.max(c1-s1/2, c2-s2/2));
+		const overr = Math.max(0, Math.min(r1 + s1 / 2, r2 + s2 / 2) - Math.max(r1 - s1 / 2, r2 - s2 / 2));
+		const overc = Math.max(0, Math.min(c1 + s1 / 2, c2 + s2 / 2) - Math.max(c1 - s1 / 2, c2 - s2 / 2));
 		// calculate and return IoU
-		return overr*overc/(s1*s1+s2*s2-overr*overc);
+		return (overr * overc) / (s1 * s1 + s2 * s2 - overr * overc);
 	}
 	/*
 		do clustering through non-maximum suppression
 	*/
 	const assignments = new Array(dets.length).fill(0);
 	const clusters = [];
-	for(let i=0; i<dets.length; ++i)
-	{
+	for (let i = 0; i < dets.length; ++i) {
 		// is this detection assigned to a cluster?
-		if(assignments[i]==0)
-		{
+		if (assignments[i] == 0) {
 			// it is not:
 			// now we make a cluster out of it and see whether some other detections belong to it
-			let r=0.0, c=0.0, s=0.0, q=0.0, n=0;
-			for(let j=i; j<dets.length; ++j)
-				if(calculate_iou(dets[i], dets[j])>iouthreshold)
-				{
+			let r = 0.0,
+				c = 0.0,
+				s = 0.0,
+				q = 0.0,
+				n = 0;
+			for (let j = i; j < dets.length; ++j) {
+				if (calculate_iou(dets[i], dets[j]) > iouthreshold) {
 					assignments[j] = 1;
 					r = r + dets[j][0];
 					c = c + dets[j][1];
@@ -161,35 +173,36 @@ pico.cluster_detections = function(dets, iouthreshold)
 					q = q + dets[j][3];
 					n = n + 1;
 				}
+			}
 			// make a cluster representative
-			clusters.push([r/n, c/n, s/n, q]);
+			clusters.push([r / n, c / n, s / n, q]);
 		}
 	}
 
 	return clusters;
-}
+};
 
-pico.instantiate_detection_memory = function(size)
-{
+pico.instantiate_detection_memory = function (size) {
 	/*
 		initialize a circular buffer of `size` elements
 	*/
 	let n = 0;
 	const memory = [];
-	for(let i=0; i<size; ++i)
+	for (let i = 0; i < size; ++i) {
 		memory.push([]);
+	}
 	/*
 		build a function that:
 		(1) inserts the current frame's detections into the buffer;
 		(2) merges all detections from the last `size` frames and returns them
 	*/
-	function update_memory(dets)
-	{
+	function update_memory(dets) {
 		memory[n] = dets;
-		n = (n+1)%memory.length;
+		n = (n + 1) % memory.length;
 		dets = [];
-		for(let i=0; i<memory.length; ++i)
+		for (let i = 0; i < memory.length; ++i) {
 			dets = dets.concat(memory[i]);
+		}
 		//
 		return dets;
 	}
@@ -197,4 +210,4 @@ pico.instantiate_detection_memory = function(size)
 		we're done
 	*/
 	return update_memory;
-}
+};


### PR DESCRIPTION
Following up on #30, this PR:

* fixes up some more of those stray globals (with some help from Eslint)
* applies the Eslint `curly` fix to add braces to some otherwise ambiguous `for`/`if` statements
* applies global code style via an adapted Prettier configuration file